### PR TITLE
feat: php8.1 upgrade

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,5 +21,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           default_branch: main
-          tags: "latest,php74"
+          tags: "latest,php81"
           cache: ${{ github.event_name != 'schedule' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4
+FROM php:8.1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -9,7 +9,7 @@ RUN echo "" \
   && apt-get update \
   && apt-get install -y \
   libicu-dev libxml2-dev libfreetype6-dev libjpeg62-turbo-dev \
-  libpng-dev libonig-dev libmagickwand-dev python-dev unzip \
+  libpng-dev libonig-dev libmagickwand-dev python-dev-is-python3 unzip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && docker-php-ext-configure gd --with-freetype --with-jpeg \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-php-with-imagick
 
-PHP 7.4 with imagick for specific purposes
+PHP 8.1 with imagick for specific purposes
 
 ## Building locally
 


### PR DESCRIPTION
This pull request updates the PHP version used in the Docker setup from 7.4 to 8.1. The changes affect multiple files, including the Dockerfile, GitHub workflow configuration, and the README documentation.

PHP version update:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL24-R24): Updated the Docker tags to reflect the new PHP version `php81`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Changed the base image from `php:7.4` to `php:8.1`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L12-R12): Updated the package `python-dev` to `python-dev-is-python3` to ensure compatibility with the new PHP version.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the documentation to indicate the use of PHP 8.1 with imagick.